### PR TITLE
Feature/#7 update collection

### DIFF
--- a/src/main/java/com/example/collection_medicine/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/collection_medicine/config/RestTemplateConfig.java
@@ -1,0 +1,23 @@
+package com.example.collection_medicine.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+
+@Configuration
+public class RestTemplateConfig {
+    @Value("${rest-template.connect-timeout}") private int connectTimeout;
+    @Value("${rest-template.read-timeout}") private int readTimeout;
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder
+                .setConnectTimeout(Duration.ofSeconds(connectTimeout))
+                .setReadTimeout(Duration.ofSeconds(readTimeout))
+                .build();
+    }
+}

--- a/src/main/java/com/example/collection_medicine/domain/Medicine.java
+++ b/src/main/java/com/example/collection_medicine/domain/Medicine.java
@@ -18,7 +18,7 @@ public class Medicine extends BaseEntity {
     private Long id;
 
     @Column(length = 4000) private String company; // 업체명
-    @Column(length = 4000) private String productName; // 제품명
+    @Column(length = 700) private String productName; // 제품명
     @Column(length = 400000000) private String efficacy; // 효능
     @Column(length = 400000000) private String useMethod; // 사용법
     @Column(length = 400000000) private String precautionsWarning; // 주의사항 경고

--- a/src/main/java/com/example/collection_medicine/domain/Medicine.java
+++ b/src/main/java/com/example/collection_medicine/domain/Medicine.java
@@ -7,6 +7,9 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(indexes = {
+        @Index(columnList = "productName")
+})
 @Entity
 public class Medicine extends BaseEntity {
 

--- a/src/main/java/com/example/collection_medicine/dto/MedicineCompareDto.java
+++ b/src/main/java/com/example/collection_medicine/dto/MedicineCompareDto.java
@@ -1,0 +1,60 @@
+package com.example.collection_medicine.dto;
+
+import com.example.collection_medicine.domain.Medicine;
+import com.example.collection_medicine.dto.constant.DmFlag;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+public class MedicineCompareDto {
+    private String company;
+    private String productName;
+    private String efficacy;
+    private String useMethod;
+    private String precautionsWarning;
+    private String caution;
+    private String interaction;
+    private String sideEffect;
+    private String storageMethod;
+    private String image;
+    private DmFlag dmFlag;
+
+    public String getKey() {
+        return company + "-" + productName;
+    }
+
+    public static MedicineCompareDto from(Medicine medicine) {
+        return new MedicineCompareDto(
+                medicine.getCompany(),
+                medicine.getProductName(),
+                medicine.getEfficacy(),
+                medicine.getUseMethod(),
+                medicine.getPrecautionsWarning(),
+                medicine.getCaution(),
+                medicine.getInteraction(),
+                medicine.getSideEffect(),
+                medicine.getStorageMethod(),
+                medicine.getImage(),
+                DmFlag.NONE);
+    }
+
+    public Medicine toEntity() {
+        return Medicine.of(
+                company,
+                productName,
+                efficacy,
+                useMethod,
+                precautionsWarning,
+                caution,
+                interaction,
+                sideEffect,
+                storageMethod,
+                image
+        );
+    }
+}

--- a/src/main/java/com/example/collection_medicine/dto/OpenApiMedicineResponse.java
+++ b/src/main/java/com/example/collection_medicine/dto/OpenApiMedicineResponse.java
@@ -4,8 +4,8 @@ import com.example.collection_medicine.domain.Medicine;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Builder
 public record OpenApiMedicineResponse(
@@ -14,24 +14,22 @@ public record OpenApiMedicineResponse(
 ) {
 
     public static List<Medicine> toEntityList(OpenApiMedicineResponse response) {
-        List<Medicine> entityList = new ArrayList<>();
-
-        for(Body.Item item : response.body().items) {
-            entityList.add(Medicine.of(
-                    item.entpName,
-                    item.itemName,
-                    item.efcyQesitm,
-                    item.useMethodQesitm,
-                    item.atpnWarnQesitm,
-                    item.atpnQesitm,
-                    item.intrcQesitm,
-                    item.seQesitm,
-                    item.depositMethodQesitm,
-                    item.itemImage
-            ));
-        }
-
-        return entityList;
+        return response.body.items.stream()
+                .map(item -> {
+                    return Medicine.of(
+                            item.entpName,
+                            item.itemName,
+                            item.efcyQesitm,
+                            item.useMethodQesitm,
+                            item.atpnWarnQesitm,
+                            item.atpnQesitm,
+                            item.intrcQesitm,
+                            item.seQesitm,
+                            item.depositMethodQesitm,
+                            item.itemImage
+                    );
+                })
+                .collect(Collectors.toList());
     }
 
     public record Header(String resultCode,

--- a/src/main/java/com/example/collection_medicine/dto/constant/DmFlag.java
+++ b/src/main/java/com/example/collection_medicine/dto/constant/DmFlag.java
@@ -1,0 +1,5 @@
+package com.example.collection_medicine.dto.constant;
+
+public enum DmFlag {
+    NONE, CREATE, UPDATE
+}

--- a/src/main/java/com/example/collection_medicine/repository/MedicineCustomRepository.java
+++ b/src/main/java/com/example/collection_medicine/repository/MedicineCustomRepository.java
@@ -1,0 +1,84 @@
+package com.example.collection_medicine.repository;
+
+import com.example.collection_medicine.domain.Medicine;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Repository
+public class MedicineCustomRepository {
+    private final JdbcTemplate jdbcTemplate;
+
+    public void bulkSave(List<Medicine> medicines) {
+        String sql = "INSERT INTO health.medicine" +
+                "(company, product_name, efficacy," +
+                "use_method, precautions_warning, caution, interaction, side_effect," +
+                "storage_method, image)" +
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+        jdbcTemplate.batchUpdate(
+                sql, new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        Medicine medicine = medicines.get(i);
+                        ps.setString(1, medicine.getCompany());
+                        ps.setString(2, medicine.getProductName());
+                        ps.setString(3, medicine.getEfficacy());
+                        ps.setString(4, medicine.getUseMethod());
+                        ps.setString(5, medicine.getPrecautionsWarning());
+                        ps.setString(6, medicine.getCaution());
+                        ps.setString(7, medicine.getInteraction());
+                        ps.setString(8, medicine.getSideEffect());
+                        ps.setString(9, medicine.getStorageMethod());
+                        ps.setString(10, medicine.getImage());
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return medicines.size();
+                    }
+                });
+    }
+
+    public void bulkUpdate(List<Medicine> medicines) {
+        String sql = "UPDATE health.medicine SET " +
+                "efficacy = ?, " +
+                "use_method = ?, " +
+                "precautions_warning = ?, " +
+                "caution = ?, " +
+                "interaction = ?, " +
+                "side_effect = ?, " +
+                "storage_method = ?, " +
+                "image = ? " +
+                "WHERE company = ? AND product_name = ? ";
+
+        jdbcTemplate.batchUpdate(
+                sql, new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        Medicine medicine = medicines.get(i);
+                        ps.setString(1, medicine.getEfficacy());
+                        ps.setString(2, medicine.getUseMethod());
+                        ps.setString(3, medicine.getPrecautionsWarning());
+                        ps.setString(4, medicine.getCaution());
+                        ps.setString(5, medicine.getInteraction());
+                        ps.setString(6, medicine.getSideEffect());
+                        ps.setString(7, medicine.getStorageMethod());
+                        ps.setString(8, medicine.getImage());
+                        ps.setString(9, medicine.getCompany());
+                        ps.setString(10, medicine.getProductName());
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return medicines.size();
+                    }
+                });
+    }
+}

--- a/src/main/java/com/example/collection_medicine/service/CollectionService.java
+++ b/src/main/java/com/example/collection_medicine/service/CollectionService.java
@@ -1,7 +1,9 @@
 package com.example.collection_medicine.service;
 
 import com.example.collection_medicine.domain.Medicine;
+import com.example.collection_medicine.dto.MedicineCompareDto;
 import com.example.collection_medicine.dto.OpenApiMedicineResponse;
+import com.example.collection_medicine.repository.MedicineCustomRepository;
 import com.example.collection_medicine.repository.MedicineRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,55 +12,91 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static com.example.collection_medicine.dto.constant.DmFlag.CREATE;
+import static com.example.collection_medicine.dto.constant.DmFlag.UPDATE;
 
 @Slf4j
 @RequiredArgsConstructor
-//@Transactional
+@Transactional
 @Service
 public class CollectionService {
     @Value("${open-api.url}") private String apiUrl;
     @Value("${open-api.decoding-key}") private String decodingKey;
 
+    private final RestTemplate restTemplate;
+    private final MedicineCustomRepository medicineCustomRepository;
     private final MedicineRepository medicineRepository;
+    private final CompareService compareService;
 
     @Scheduled(initialDelayString = "${scheduled.initial-delay}", fixedRateString = "${scheduled.fixed-rate}", timeUnit = TimeUnit.SECONDS)
-    public void collectMedicine() throws IOException {
-        RestTemplate restTemplate = new RestTemplate();
+    public void collectMedicine() {
+        List<Medicine> dbMedicines = medicineRepository.findAll();
+        List<Medicine> apiMedicines = fetchMedicinesFromApi();
 
-        int pageNo = 1;
+        List<MedicineCompareDto> dbMedicineDtoList = dbMedicines.stream()
+                .map(MedicineCompareDto::from)
+                .collect(Collectors.toList());
+        List<MedicineCompareDto> apiMedicineDtoList = apiMedicines.stream()
+                .map(MedicineCompareDto::from)
+                .collect(Collectors.toList());
 
-        for (int i = 0; i < pageNo; i++) {
-            URI uri = createUrl(i + 1);
+        // db 동기화를 위해 db 데이터와 api 데이터를 비교한다.
+        compareService.medicineCompare(dbMedicineDtoList, apiMedicineDtoList);
+
+        List<Medicine> insertMedicines = apiMedicineDtoList.stream()
+                .filter(medicineCompareDto -> CREATE == medicineCompareDto.getDmFlag())
+                .map(MedicineCompareDto::toEntity)
+                .collect(Collectors.toList());
+        log.info("insert size {}", insertMedicines.size());
+        List<Medicine> updateMedicines = apiMedicineDtoList.stream()
+                .filter(medicineCompareDto -> UPDATE == medicineCompareDto.getDmFlag())
+                .map(MedicineCompareDto::toEntity)
+                .collect(Collectors.toList());
+        log.info("update size {}", updateMedicines.size());
+
+        medicineCustomRepository.bulkSave(insertMedicines);
+        medicineCustomRepository.bulkUpdate(updateMedicines);
+    }
+
+    private List<Medicine> fetchMedicinesFromApi() {
+        List<Medicine> medicines = new ArrayList<>();
+
+        int maxPage = 1;
+        for (int pageNo = 0; pageNo < 1; pageNo++) {
+            URI uri = createUrl(pageNo + 1);
 
             try {
-                ResponseEntity<OpenApiMedicineResponse> responseEntity = restTemplate.exchange(
+                ResponseEntity<OpenApiMedicineResponse> response = restTemplate.exchange(
                         uri, HttpMethod.GET, null, OpenApiMedicineResponse.class);
-                log.info("response header = {}", responseEntity.getBody().header());
-                log.info("response body = {}", responseEntity.getBody().body());
+                log.info("response header = {}", response.getBody().header());
+                log.info("response body = {}", response.getBody().body());
 
-                List<Medicine> entityList = OpenApiMedicineResponse.toEntityList(responseEntity.getBody());
-                medicineRepository.saveAll(entityList);
+                List<Medicine> resMedicines = OpenApiMedicineResponse.toEntityList(response.getBody());
+                medicines.addAll(resMedicines);
 
-                if (i == 0) {
-                    pageNo = responseEntity.getBody().body().totalCount();
+                if (pageNo == 0) {
+                    maxPage = response.getBody().body().totalCount();
                 }
             } catch (RestClientException e) {
                 log.warn("Request error. {}", e.getLocalizedMessage());
             }
         }
+
+        return medicines;
     }
 
-    private URI createUrl(int pageNo) throws UnsupportedEncodingException {
+    private URI createUrl(int pageNo) {
         UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(apiUrl)
                 .queryParam("serviceKey", decodingKey)
                 .queryParam("pageNo", pageNo)

--- a/src/main/java/com/example/collection_medicine/service/CompareService.java
+++ b/src/main/java/com/example/collection_medicine/service/CompareService.java
@@ -1,0 +1,45 @@
+package com.example.collection_medicine.service;
+
+import com.example.collection_medicine.dto.MedicineCompareDto;
+import com.example.collection_medicine.dto.constant.DmFlag;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+
+@Service
+public class CompareService {
+
+    public void medicineCompare(List<MedicineCompareDto> dbDtoList, List<MedicineCompareDto> apiDtoList) {
+        for (MedicineCompareDto apiDto : apiDtoList) {
+            boolean exist = false;
+
+            for (MedicineCompareDto dbDto : dbDtoList) {
+                if(apiDto.getKey().equals(dbDto.getKey())) {
+                    exist = true;
+                    apiDto.setDmFlag(DmFlag.NONE);
+                    checkUpdateColumn(apiDto, dbDto);
+                    break;
+                }
+            }
+
+            if(!exist) {
+                apiDto.setDmFlag(DmFlag.CREATE);
+            }
+        }
+    }
+
+    private void checkUpdateColumn(MedicineCompareDto apiDto, MedicineCompareDto dbDto) {
+        if (!Objects.equals(apiDto.getEfficacy(), dbDto.getEfficacy()) ||
+                !Objects.equals(apiDto.getUseMethod(), dbDto.getUseMethod()) ||
+                !Objects.equals(apiDto.getPrecautionsWarning(), dbDto.getPrecautionsWarning()) ||
+                !Objects.equals(apiDto.getCaution(), dbDto.getCaution()) ||
+                !Objects.equals(apiDto.getInteraction(), dbDto.getInteraction()) ||
+                !Objects.equals(apiDto.getSideEffect(), dbDto.getSideEffect()) ||
+                !Objects.equals(apiDto.getStorageMethod(), dbDto.getStorageMethod()) ||
+                !Objects.equals(apiDto.getImage(), dbDto.getImage())) {
+            apiDto.setDmFlag(DmFlag.UPDATE);
+        }
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,11 +1,5 @@
-debug: false
-management.endpoints.web.exposure.include: "*"
-
-logging:
-  level:
-    com.example: debug
-    org.springframework.web.servlet: debug
-    org.hibernate.type.descriptor.sql.BasicBinder: trace
+server:
+  port: 8081
 
 spring:
   config:
@@ -17,7 +11,8 @@ spring:
     password: ${LOCAL_MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
-    defer-datasource-initialization: true # 실제 데이터베이스와의 연결이 필요한 시점에서 초기화
+    open-in-view: false
+    defer-datasource-initialization: true
     hibernate.ddl-auto: create
     show-sql: true
     properties:
@@ -25,14 +20,13 @@ spring:
       hibernate.default_batch_fetch_size: 100
   sql.init.mode: always
 
-
 open-api:
   decoding-key: ${DECODING_KET}
   url: ${API_URL}
 
 #초 단위
 scheduled:
-  initial-delay: 100
+  initial-delay: 10
   fixed-rate: 604800 # 1주일
 
 # 초 단위

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,5 +35,10 @@ scheduled:
   initial-delay: 100
   fixed-rate: 604800 # 1주일
 
+# 초 단위
+rest-template:
+  connect-timeout: 5
+  read-timeout: 5
+
 
 


### PR DESCRIPTION
## ⭐ 개요
* medicine 테이블 외부 동기화 로직 수정

### 종류
- [ ] New Feature

### 📑 주요 작성/변경사항
- [ ] 


### 💡 특이 사항
* medicine 테이블 'product_name' 컬럼 인덱스 설정
* RestTemplat 타임아웃 설정
* jpa 설정 변경
* 포트 8080에서 8081로 변경
```
 jpa:
    open-in-view: false   # false로 지정하면 영속성 컨텍스트의 생존범위가 트랜잭션 범위로 줄어듬. 그로인해 성능 향상 (원래는 컨트롤러까지 생존함, 우리는 컨트롤러에서 entity를 사용할 일이 없으니깐 false로 지정해도 되지 않을까..?)
    defer-datasource-initialization: true # sql 스크립트가 hibernate 초기화 이후 실행되도록 변경한다. (boot 2.5 부터 초기화 이전에 실행됨)
    hibernate.ddl-auto: create
    show-sql: true
    properties:
      hibernate.format_sql: true # sql 문 보기 편하게 설정
      hibernate.default_batch_fetch_size: 100 # 지연로딩시 배치 사이즈를 100으로 지정
  sql.init.mode: always # 애플리케이션 구동시 sql 스크립트 항상 실행하도록 설정
```

### #️⃣ closes - #7 

### Reference